### PR TITLE
Added Apollo multi-query request support

### DIFF
--- a/Controller/GraphQLController.php
+++ b/Controller/GraphQLController.php
@@ -31,7 +31,7 @@ class GraphQLController extends Controller
             return $this->createEmptyResponse();
         }
 
-        list($query, $variables) = $this->getPayload();
+        list($queries, $isMultiQueryRequest) = $this->getPayload();
 
         $schemaClass = $this->getParameter('graphql.schema_class');
         if (!$schemaClass || !class_exists($schemaClass)) {
@@ -47,11 +47,11 @@ class GraphQLController extends Controller
             $this->get('service_container')->set('graphql.schema', $schema);
         }
 
-        /** @var Processor $processor */
-        $processor = $this->get('graphql.processor');
-        $processor->processPayload($query, $variables);
+        $queryResponses = array_map(function($queryData) {
+            return $this->executeQuery($queryData['query'], $queryData['variables']);
+        }, $queries);
 
-        $response = new JsonResponse($processor->getResponseData(), 200, $this->getParameter('graphql.response.headers'));
+        $response = new JsonResponse($isMultiQueryRequest ? $queryResponses : $queryResponses[0], 200, $this->getParameter('graphql.response.headers'));
 
         if ($this->getParameter('graphql.response.json_pretty')) {
             $response->setEncodingOptions($response->getEncodingOptions() | JSON_PRETTY_PRINT);
@@ -65,37 +65,67 @@ class GraphQLController extends Controller
         return new JsonResponse([], 200, $this->getParameter('graphql.response.headers'));
     }
 
+    private function executeQuery($query, $variables)
+    {
+        /** @var Processor $processor */
+        $processor = $this->get('graphql.processor');
+        $processor->processPayload($query, $variables);
+
+        return $processor->getResponseData();
+    }
+
     private function getPayload()
     {
         $request   = $this->get('request_stack')->getCurrentRequest();
         $query     = $request->get('query', null);
         $variables = $request->get('variables', []);
+        $isMultiQueryRequest = false;
+        $queries = [];
 
         $variables = is_string($variables) ? json_decode($variables, true) ?: [] : [];
 
         $content = $request->getContent();
         if (!empty($content)) {
             if ($request->headers->has('Content-Type') && 'application/graphql' == $request->headers->get('Content-Type')) {
-                $query = $content;
+                $queries[] = $content;
             } else {
                 $params = json_decode($content, true);
 
                 if ($params) {
-                    $query = isset($params['query']) ? $params['query'] : $query;
+                    // check for a list of queries
+                    if (isset($params[0]) === true) {
+                        $isMultiQueryRequest = true;
+                    } else {
+                        $params = [$params];
+                    }
 
-                    if (isset($params['variables'])) {
-                        if (is_string($params['variables'])) {
-                            $variables = json_decode($params['variables'], true) ?: $variables;
-                        } else {
-                            $variables = $params['variables'];
+                    foreach ($params as $queryParams) {
+                        $query = isset($queryParams['query']) ? $queryParams['query'] : $query;
+
+                        if (isset($queryParams['variables'])) {
+                            if (is_string($queryParams['variables'])) {
+                                $variables = json_decode($queryParams['variables'], true) ?: $variables;
+                            } else {
+                                $variables = $queryParams['variables'];
+                            }
+
+                            $variables = is_array($variables) ? $variables : [];
                         }
 
-                        $variables = is_array($variables) ? $variables : [];
+                        $queries[] = [
+                            'query' => $query,
+                            'variables' => $variables,
+                        ];
                     }
                 }
             }
+        } else {
+            $queries[] = [
+                'query' => $query,
+                'variables' => $variables,
+            ];
         }
 
-        return [$query, $variables];
+        return [$queries, $isMultiQueryRequest];
     }
 }


### PR DESCRIPTION
This PR adds support for executing multiple queries in a single request from Apollo. We've tested in a number of scenarios and it works well. 

Being able to support this use-case has reduced our query time dramatically because of batching.