### PR TITLE
Fix to application/graphql content type requests after fixing multi-q…

### DIFF
--- a/Controller/GraphQLController.php
+++ b/Controller/GraphQLController.php
@@ -87,7 +87,10 @@ class GraphQLController extends Controller
         $content = $request->getContent();
         if (!empty($content)) {
             if ($request->headers->has('Content-Type') && 'application/graphql' == $request->headers->get('Content-Type')) {
-                $queries[] = $content;
+                $queries[] = [
+                    'query' => $content,
+                    'variables' => [],
+                ];
             } else {
                 $params = json_decode($content, true);
 


### PR DESCRIPTION
…uery request support

Due to this documentation:

http://graphql.org/learn/serving-over-http/

If the "application/graphql" Content-Type header is present, treat the HTTP POST body contents as the GraphQL query string.

So query equals to body in case of application/graphql content type. It was like that in 1.3.1