### PR TITLE
[FEATURE] Enable real DependencyInjection into Schema

### DIFF
--- a/Controller/GraphQLController.php
+++ b/Controller/GraphQLController.php
@@ -39,9 +39,13 @@ class GraphQLController extends Controller
         }
 
         if (!$this->get('service_container')->initialized('graphql.schema')) {
-            $schema = new $schemaClass();
-            if ($schema instanceof ContainerAwareInterface) {
-                $schema->setContainer($this->get('service_container'));
+            if ($this->container->has($schemaClass)) {
+                $schema = $this->container->get($schemaClass);
+            } else {
+                $schema = new $schemaClass();
+                if ($schema instanceof ContainerAwareInterface) {
+                    $schema->setContainer($this->get('service_container'));
+                }
             }
 
             $this->get('service_container')->set('graphql.schema', $schema);


### PR DESCRIPTION
Starting with Symfony 3.3 you can use the real className as Service ID, this enables you to add your dependencies in the constructor of your Schema and get a properly injected Object without toying around with the container itself:

```php
class Schema extends AbstractSchema
{
    /**
     * @var SomeRepository
     */
    protected $someRepository;

    /**
     * Schema constructor.
     * @param array $config
     * @param SomeRepository|null $someRepository
     */
    public function __construct(array $config = [], SomeRepository $someRepository = null)
    {
        $this->someRepository = $someRepository;
        parent::__construct($config);
    }
}
```