### PR TITLE
Fix license info in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "youshido/graphql-bundle",
   "description": "Symfony GraphQl Bundle",
-  "license": "proprietary",
+  "license": "MIT",
   "authors": [
     {
       "name": "Portey Vasil",


### PR DESCRIPTION
According to the LICENSE file the bundle is open source under the MIT license. This commit updates the composer.json to reflect this fact.