### PR TITLE
Fix #47: Not able to inject a custom schema service

### DIFF
--- a/Controller/GraphQLController.php
+++ b/Controller/GraphQLController.php
@@ -7,17 +7,16 @@
 
 namespace Youshido\GraphQLBundle\Controller;
 
-
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Youshido\GraphQL\Validator\Exception\ConfigurationException;
+use Youshido\GraphQLBundle\Exception\UnableToInitializeSchemaServiceException;
 use Youshido\GraphQLBundle\Execution\Processor;
 
 class GraphQLController extends Controller
 {
-
     /**
      * @Route("/graphql")
      *
@@ -27,29 +26,21 @@ class GraphQLController extends Controller
      */
     public function defaultAction()
     {
+        try {
+            $this->initializeSchemaService();
+        } catch (UnableToInitializeSchemaServiceException $e) {
+            return new JsonResponse(
+                [['message' => 'Schema class ' . $this->getSchemaClass() . ' does not exist']],
+                200,
+                $this->getResponseHeaders()
+            );
+        }
+
         if ($this->get('request_stack')->getCurrentRequest()->getMethod() == 'OPTIONS') {
             return $this->createEmptyResponse();
         }
 
         list($queries, $isMultiQueryRequest) = $this->getPayload();
-
-        $schemaClass = $this->getParameter('graphql.schema_class');
-        if (!$schemaClass || !class_exists($schemaClass)) {
-            return new JsonResponse([['message' => 'Schema class ' . $schemaClass . ' does not exist']], 200, $this->getParameter('graphql.response.headers'));
-        }
-
-        if (!$this->get('service_container')->initialized('graphql.schema')) {
-            if ($this->container->has($schemaClass)) {
-                $schema = $this->container->get($schemaClass);
-            } else {
-                $schema = new $schemaClass();
-                if ($schema instanceof ContainerAwareInterface) {
-                    $schema->setContainer($this->get('service_container'));
-                }
-            }
-
-            $this->get('service_container')->set('graphql.schema', $schema);
-        }
 
         $queryResponses = array_map(function($queryData) {
             return $this->executeQuery($queryData['query'], $queryData['variables']);
@@ -66,7 +57,7 @@ class GraphQLController extends Controller
 
     private function createEmptyResponse()
     {
-        return new JsonResponse([], 200, $this->getParameter('graphql.response.headers'));
+        return new JsonResponse([], 200, $this->getResponseHeaders());
     }
 
     private function executeQuery($query, $variables)
@@ -80,8 +71,8 @@ class GraphQLController extends Controller
 
     private function getPayload()
     {
-        $request   = $this->get('request_stack')->getCurrentRequest();
-        $query     = $request->get('query', null);
+        $request = $this->get('request_stack')->getCurrentRequest();
+        $query = $request->get('query', null);
         $variables = $request->get('variables', []);
         $isMultiQueryRequest = false;
         $queries = [];
@@ -131,5 +122,64 @@ class GraphQLController extends Controller
         }
 
         return [$queries, $isMultiQueryRequest];
+    }
+
+    private function initializeSchemaService()
+    {
+        if ($this->container->initialized('graphql.schema')) {
+            return;
+        }
+
+        $this->container->set('graphql.schema', $this->makeSchemaService());
+    }
+
+    private function makeSchemaService()
+    {
+        if ($this->container->has($this->getSchemaService())) {
+            return $this->container->get($this->getSchemaService());
+        }
+
+        $schemaClass = $this->getSchemaClass();
+        if (!$schemaClass || !class_exists($schemaClass)) {
+            throw new UnableToInitializeSchemaServiceException();
+        }
+
+        if ($this->container->has($schemaClass)) {
+            return $this->container->get($schemaClass);
+        }
+
+        $schema = new $schemaClass();
+        if ($schema instanceof ContainerAwareInterface) {
+            $schema->setContainer($this->container);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @return string
+     */
+    private function getSchemaClass()
+    {
+        return $this->getParameter('graphql.schema_class');
+    }
+
+    /**
+     * @return string
+     */
+    private function getSchemaService()
+    {
+        $serviceName = $this->getParameter('graphql.schema_service');
+
+        if (substr($serviceName, 0, 1) === '@') {
+            return substr($serviceName, 1, strlen($serviceName) - 1);
+        }
+
+        return $serviceName;
+    }
+
+    private function getResponseHeaders()
+    {
+        return $this->getParameter('graphql.response.headers');
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,8 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('schema_class')->cannotBeEmpty()->defaultValue(null)->end()
+                ->scalarNode('schema_class')->defaultValue(null)->end()
+                ->scalarNode('schema_service')->defaultValue(null)->end()
                 ->integerNode('max_complexity')->defaultValue(null)->end()
                 ->scalarNode('logger')->defaultValue(null)->end()
                 ->arrayNode('security')

--- a/DependencyInjection/GraphQLExtension.php
+++ b/DependencyInjection/GraphQLExtension.php
@@ -14,7 +14,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class GraphQLExtension extends Extension
 {
-
     private $config = [];
 
     /**
@@ -33,6 +32,7 @@ class GraphQLExtension extends Extension
 
         $container->setParameter('graphql.response.headers', $preparedHeaders);
         $container->setParameter('graphql.schema_class', $this->config['schema_class']);
+        $container->setParameter('graphql.schema_service', $this->config['schema_service']);
         $container->setParameter('graphql.logger', $this->config['logger']);
         $container->setParameter('graphql.max_complexity', $this->config['max_complexity']);
         $container->setParameter('graphql.response.json_pretty', $this->config['response']['json_pretty']);

--- a/Exception/UnableToInitializeSchemaServiceException.php
+++ b/Exception/UnableToInitializeSchemaServiceException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Youshido\GraphQLBundle\Exception;
+
+class UnableToInitializeSchemaServiceException extends \Exception
+{
+}


### PR DESCRIPTION
This PR attempts to fix #47 

By adding a new optional configuration parameter ([`graphql.schema_service`](https://github.com/MLoureiro/GraphQLBundle/blob/8ddd8ada484749af28927426b263506491b69894/DependencyInjection/Configuration.php#L27)) and improving the way to [load the service](https://github.com/MLoureiro/GraphQLBundle/blob/8ddd8ada484749af28927426b263506491b69894/Controller/GraphQLController.php#L136).

No tests were added since there are none.
