### PR TITLE
Fixed Processor::__construct parameter

### DIFF
--- a/Execution/Processor.php
+++ b/Execution/Processor.php
@@ -42,7 +42,7 @@ class Processor extends BaseProcessor
         $this->executionContext = $executionContext;
         $this->eventDispatcher = $eventDispatcher;
 
-        parent::__construct($executionContext->getSchema());
+        parent::__construct($executionContext);
     }
 
     /**


### PR DESCRIPTION
Type error: Argument 1 passed to Youshido\GraphQL\Execution\Processor::__construct() must implement interface Youshido\GraphQL\Execution\Context\ExecutionContextInterface, instance of AppBundle\GraphQL\Schema given, called in /home/big_shark/work/aa_rebuild/vendor/youshido/graphql-bundle/Execution/Processor.php on line 45