### PR TITLE
Allows resolve event listeners to override or manipulate the resolved result

### DIFF
--- a/Event/ResolveEvent.php
+++ b/Event/ResolveEvent.php
@@ -14,18 +14,23 @@ class ResolveEvent extends GenericEvent
 
     /** @var array */
     private $astFields;
+    
+    /** @var mixed|null */
+    private $resolvedValue;
 
     /**
      * Constructor.
      *
      * @param FieldInterface $field
      * @param array $astFields
+     * @param mixed|null $resolvedValue
      */
-    public function __construct(FieldInterface $field, array $astFields)
+    public function __construct(FieldInterface $field, array $astFields, $resolvedValue = null)
     {
         $this->field = $field;
         $this->astFields = $astFields;
-        parent::__construct('ResolveEvent', [$field, $astFields]);
+        $this->resolvedValue = $resolvedValue;
+        parent::__construct('ResolveEvent', [$field, $astFields, $resolvedValue]);
     }
 
     /**
@@ -47,4 +52,25 @@ class ResolveEvent extends GenericEvent
     {
         return $this->astFields;
     }
+
+    /**
+     * Returns the resolved value.
+     * 
+     * @return mixed|null
+     */
+    public function getResolvedValue()
+    {
+        return $this->resolvedValue;
+    }
+
+    /**
+     * Allows the event listener to manipulate the resolved value.
+     * 
+     * @param $resolvedValue
+     */
+    public function setResolvedValue($resolvedValue)
+    {
+        $this->resolvedValue = $resolvedValue;
+    }
 }
+

--- a/Execution/Processor.php
+++ b/Execution/Processor.php
@@ -116,9 +116,9 @@ class Processor extends BaseProcessor
             $result = $field->resolve($parentValue, $arguments, $resolveInfo);
         }
 
-        $event = new ResolveEvent($field, $astFields);
+        $event = new ResolveEvent($field, $astFields, $result);
         $this->eventDispatcher->dispatch('graphql.post_resolve', $event);
-        return $result;
+        return $event->getResolvedValue();
     }
 
     private function assertClientHasOperationAccess(Query $query)


### PR DESCRIPTION
We have a use case for translations. Internally we use keys and only translate at the edge of our application. This allows us to easily intercept these values and translate them.

It seems fair that someone listening to post_resolve would want the value also.