### PR TITLE
Register configure command in container.

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -49,5 +49,9 @@
         <service id="graphql.security.voter" class="Youshido\GraphQLBundle\Security\Voter\BlacklistVoter" public="false">
             <tag name="security.voter" priority="255" />
         </service>
+
+        <service id="graphql.command.configure" class="Youshido\GraphQLBundle\Command\GraphQLConfigureCommand">
+            <tag name="console.command" command="graphql:configure"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Related to https://github.com/Youshido/GraphQLBundle/issues/68 

Command auto registration was removed in Symfony 4.0