### PR TITLE
Fix issue when resolving GlobalId field

### DIFF
--- a/Execution/Processor.php
+++ b/Execution/Processor.php
@@ -141,7 +141,7 @@ class Processor extends BaseProcessor
 
     private function isServiceReference($resolveFunc)
     {
-        return is_array($resolveFunc) && count($resolveFunc) == 2 && strpos($resolveFunc[0], '@') === 0;
+        return is_array($resolveFunc) && count($resolveFunc) == 2 && is_string($resolveFunc[0]) && strpos($resolveFunc[0], '@') === 0;
     }
 
     public function setLogger($logger = null)


### PR DESCRIPTION
I ran into a regression when upgrading from `v1.3.4` to `v1.4`

When the field passed to [doResolve()](https://github.com/Youshido/GraphQLBundle/blob/v1.4/Execution/Processor.php) is a instance of `Youshido\GraphQL\Relay\Field\GlobalIdField` the following error occurs

>[2018-03-08 09:58:51] app.WARNING: strpos() expects parameter 1 to be string, object given {"exception":"[object] (PHPUnit\\Framework\\Error\\Warning(code: 2): strpos() expects parameter 1 to be string, object given at vendor/youshido/graphql-bundle/Execution/Processor.php:148)"} []