### PR TITLE
Removed warning in console

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -51,6 +51,7 @@
 
         <service id="graphql.command.configure" class="Youshido\GraphQLBundle\Command\GraphQLConfigureCommand">
             <tag name="console.command" command="graphql:configure"/>
+            <argument type="service" id="router" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
```
  Too few arguments to function Youshido\GraphQLBundle\Command\GraphQLConfigureCommand::__construct(), 0 passed in var/cache/prod/ContainerYK9QSxf/App_KernelProdContainer.php on  
   line 38382 and exactly 1 expected                                                                                                                                                                         
```

Added router argument in command service configuration to avoid this error.